### PR TITLE
Adding text to Lumache's Documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,6 +6,8 @@ that creates recipes mixing random ingredients.
 It pulls data from the `Open Food Facts database <https://world.openfoodfacts.org/>`_
 and offers a *simple* and *intuitive* API.
 
+Lumache has its documentation hosted on Read the Docs.
+
 Check out the :doc:`usage` section for further information, including
 how to :ref:`installation` the project.
 


### PR DESCRIPTION
adding the location of the documentation hosting arrangement for Lumache to the description and building the docs from the pull request